### PR TITLE
Check config file exists in yaml_load, and return empty dict if not

### DIFF
--- a/src/turf/config.py
+++ b/src/turf/config.py
@@ -292,20 +292,20 @@ class BaseConfig:
 
     @classmethod
     def yaml_load(cls, config_path):
-        with open(config_path) as config_file_handle:
-            if cls.safe_load:
-                return yaml.safe_load(config_file_handle)
-            else:
-                return yaml.load(config_file_handle)
+        if config_path and os.path.exists(config_path):
+            with open(config_path) as config_file_handle:
+                if cls.safe_load:
+                    return yaml.safe_load(config_file_handle)
+                else:
+                    return yaml.load(config_file_handle)
+        else:
+            return {}
 
     @classmethod
     def read_section_from_file(cls, section_name):
         """Loads a section from its config file and parses the YAML."""
         config_path = cls.get_file_path_for_section(section_name)
-        if os.path.exists(config_path):
-            return cls.yaml_load(config_path)
-        else:
-            return {}
+        return cls.yaml_load(config_path)
 
     @classmethod
     def raise_validation_error(cls, section, errors):

--- a/src/turf/config.py
+++ b/src/turf/config.py
@@ -346,7 +346,10 @@ class SingleFileConfig(BaseConfig):
         cls._cache = {}
         defaults = cls.get_defaults()
         schema = cls.get_schema()
-        for section_name in cls._conf_cache.keys():
+
+        keys = set(list(cls._conf_cache.keys()) + list(defaults.keys()))
+
+        for section_name in keys:
             section_defaults = defaults.get(section_name, {})
             section_schema = schema[section_name]
             cls._cache[section_name] = cls.load_section(section_name, section_defaults, section_schema)


### PR DESCRIPTION
The check was previously in `read_section_from_file` - by moving it to `yaml_load` we can take advantage of it in `SingleFileConfig`.